### PR TITLE
migrate to Sentry Node SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 2.0.0
+
+* Migration from Raven client to Sentry Node SDK client
+* Sentry removed the need to provide the secret key. Details https://docs.sentry.io/error-reporting/quickstart/?platform=node
+* `preventSentryCapture` option renamed to `preventSentryCapture`
+
+## 1.0.0
+
+* Last release using the Raven client (deprecated)

--- a/node-logger.js
+++ b/node-logger.js
@@ -1,6 +1,6 @@
-const Raven = require('raven');
+const Sentry = require('@sentry/node');
 if (process.env.SENTRY_DSN) {
-    Raven.config(process.env.SENTRY_DSN).install();
+    Sentry.init({dsn: process.env.SENTRY_DSN});
 }
 
 let sentryCallback = function(sendErr, eventId) {
@@ -24,18 +24,18 @@ module.exports.warn = function(msg, ...msgArgs) {
 };
 
 /**
- * Logs messages as errors to the console, and posts them to Sentry, via Raven library (optional)
+ * Logs messages as errors to the console, and posts them to Sentry, via Sentry Node SDK (optional)
  *
  * @param msg String - The log message
  * @param error Object - The Error Object
  * @param options Object - valid options include:
- *     -  preventRavenCapture Boolean - if true, the exception is captured with Raven
- *     -  dataContext Object - extra data to be captured with Raven
+ *     -  preventSentryCapture Boolean - if true, the exception is captured with Sentry
+ *     -  dataContext Object - extra data to be captured with Sentry
  */
 module.exports.error = function(msg, error, options = {}) {
     console.error(`ERROR ${msg}`, error);
 
-    if (process.env.SENTRY_DSN && !options.preventRavenCapture) {
+    if (process.env.SENTRY_DSN && !options.preventSentryCapture) {
         let sentryOptions = {};
         // keep checking for options.dataContext to keep compatible with older versios
         sentryOptions.extra = options.dataContext || options.extra || {};
@@ -47,9 +47,9 @@ module.exports.error = function(msg, error, options = {}) {
 
         if (error instanceof Error) {
             sentryOptions.extra.errorMessage = msg;
-            Raven.captureException(error, sentryOptions, sentryCallback);
+            Sentry.captureException(error, sentryOptions, sentryCallback);
         } else {
-            Raven.captureMessage(msg, sentryOptions, sentryCallback);
+            Sentry.captureMessage(msg, sentryOptions, sentryCallback);
         }
     }
 };

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "keywords": [
     "node",
     "logger",
-    "raven"
+    "sentry"
   ],
   "author": "Andi Studer <andi@ntslive.co.uk> (https://www.nts.live)",
   "license": "ISC",
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/ntslive/node-logger#readme",
   "dependencies": {
-    "raven": "^2.6.0"
+    "@sentry/node": "^4.5.3"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/test/node-logger-debug.spec.js
+++ b/test/node-logger-debug.spec.js
@@ -1,7 +1,6 @@
 const chai = require('chai');
 const sinonChai = require('sinon-chai');
 const sinon = require('sinon');
-const Raven = require('raven');
 
 const logger = require('../node-logger.js');
 

--- a/test/node-logger-error.spec.js
+++ b/test/node-logger-error.spec.js
@@ -1,7 +1,7 @@
 const chai = require('chai');
 const sinonChai = require('sinon-chai');
 const sinon = require('sinon');
-const Raven = require('raven');
+const Sentry = require('@sentry/node');
 
 process.env.SENTRY_DSN = 'https://1234:1234@sentry.io/4567';
 const logger = require('../node-logger.js');
@@ -12,14 +12,14 @@ chai.use(sinonChai);
 describe('Node Logger .error', function() {
     beforeEach(function() {
         sinon.spy(console, 'error');
-        sinon.spy(Raven, 'captureException');
-        sinon.spy(Raven, 'captureMessage');
+        sinon.spy(Sentry, 'captureException');
+        sinon.spy(Sentry, 'captureMessage');
     });
 
     afterEach(function() {
         console.error.restore();
-        Raven.captureException.restore();
-        Raven.captureMessage.restore();
+        Sentry.captureException.restore();
+        Sentry.captureMessage.restore();
     });
 
     describe('when called with error instance', function() {
@@ -27,8 +27,8 @@ describe('Node Logger .error', function() {
             let testError = new Error('Test Error');
             logger.error('test message', testError);
             expect(console.error).to.be.calledWith('ERROR test message', testError);
-            expect(Raven.captureException).to.be.calledWith(testError);
-            expect(Raven.captureMessage).not.to.be.called;
+            expect(Sentry.captureException).to.be.calledWith(testError);
+            expect(Sentry.captureMessage).not.to.be.called;
             done();
         });
     });
@@ -37,18 +37,18 @@ describe('Node Logger .error', function() {
         it('logs to console with Error undefined', function(done) {
             logger.error('test message');
             expect(console.error).to.be.calledWith('ERROR test message', undefined);
-            expect(Raven.captureMessage).to.be.calledWith('test message');
-            expect(Raven.captureException).not.to.be.called;
+            expect(Sentry.captureMessage).to.be.calledWith('test message');
+            expect(Sentry.captureException).not.to.be.called;
             done();
         });
     });
 
-    describe('when called with option.preventRavenCapture', function() {
+    describe('when called with option.preventSentryCapture', function() {
         it('does to send to Sentry', function(done) {
-            logger.error('test message', undefined, {preventRavenCapture: true});
+            logger.error('test message', undefined, {preventSentryCapture: true});
             expect(console.error).to.be.calledWith('ERROR test message', undefined);
-            expect(Raven.captureMessage).not.to.be.called;
-            expect(Raven.captureException).not.to.be.called;
+            expect(Sentry.captureMessage).not.to.be.called;
+            expect(Sentry.captureException).not.to.be.called;
             done();
         });
     });


### PR DESCRIPTION

- Migrates from Raven Node library to Sentry SDK
- adds CHANGELOG.md for upgrade details

Note: consider this a breaking release, so major version bump required after merge.
